### PR TITLE
Add simple Excel CRUD web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Excel Manager
+
+This simple Flask application provides a web interface to perform CRUD (create, read, update, delete) operations on a local Excel file.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+The application automatically creates `data.xlsx` if it does not exist.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,87 @@
+from flask import Flask, request, jsonify, render_template
+import openpyxl
+import os
+
+app = Flask(__name__)
+EXCEL_FILE = 'data.xlsx'
+
+
+def load_workbook():
+    if not os.path.exists(EXCEL_FILE):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["ID", "Name"])
+        wb.save(EXCEL_FILE)
+    return openpyxl.load_workbook(EXCEL_FILE)
+
+
+def read_data():
+    wb = load_workbook()
+    ws = wb.active
+    data = []
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        data.append({"id": row[0], "name": row[1]})
+    return data
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/api/data')
+def list_data():
+    return jsonify(read_data())
+
+
+@app.route('/api/add', methods=['POST'])
+def add_row():
+    id_ = request.json.get('id')
+    name = request.json.get('name')
+    if not id_ or not name:
+        return jsonify({"error": "id and name required"}), 400
+    wb = load_workbook()
+    ws = wb.active
+    ws.append([id_, name])
+    wb.save(EXCEL_FILE)
+    return jsonify({"success": True})
+
+
+@app.route('/api/update', methods=['POST'])
+def update_row():
+    id_ = request.json.get('id')
+    name = request.json.get('name')
+    if not id_ or not name:
+        return jsonify({"error": "id and name required"}), 400
+    wb = load_workbook()
+    ws = wb.active
+    for row in ws.iter_rows(min_row=2):
+        if str(row[0].value) == str(id_):
+            row[1].value = name
+            wb.save(EXCEL_FILE)
+            return jsonify({"success": True})
+    return jsonify({"error": "ID not found"}), 404
+
+
+@app.route('/api/delete', methods=['POST'])
+def delete_row():
+    id_ = request.json.get('id')
+    if not id_:
+        return jsonify({"error": "id required"}), 400
+    wb = load_workbook()
+    ws = wb.active
+    row_to_delete = None
+    for idx, row in enumerate(ws.iter_rows(min_row=2), start=2):
+        if str(row[0].value) == str(id_):
+            row_to_delete = idx
+            break
+    if row_to_delete:
+        ws.delete_rows(row_to_delete)
+        wb.save(EXCEL_FILE)
+        return jsonify({"success": True})
+    else:
+        return jsonify({"error": "ID not found"}), 404
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openpyxl

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Excel Manager</title>
+    <style>
+        table { border-collapse: collapse; }
+        td, th { border: 1px solid #ccc; padding: 4px 8px; }
+    </style>
+</head>
+<body>
+<h1>Excel Manager</h1>
+
+<table id="data-table">
+    <thead>
+    <tr><th>ID</th><th>Name</th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+
+<h2>Add Row</h2>
+<input id="add-id" placeholder="ID">
+<input id="add-name" placeholder="Name">
+<button onclick="addRow()">Add</button>
+
+<h2>Update Row</h2>
+<input id="update-id" placeholder="ID">
+<input id="update-name" placeholder="New Name">
+<button onclick="updateRow()">Update</button>
+
+<h2>Delete Row</h2>
+<input id="delete-id" placeholder="ID">
+<button onclick="deleteRow()">Delete</button>
+
+<script>
+async function fetchData() {
+    const response = await fetch('/api/data');
+    const data = await response.json();
+    const tbody = document.querySelector('#data-table tbody');
+    tbody.innerHTML = '';
+    for (const row of data) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${row.id}</td><td>${row.name}</td>`;
+        tbody.appendChild(tr);
+    }
+}
+
+async function addRow() {
+    const id = document.getElementById('add-id').value;
+    const name = document.getElementById('add-name').value;
+    await fetch('/api/add', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id, name})
+    });
+    fetchData();
+}
+
+async function updateRow() {
+    const id = document.getElementById('update-id').value;
+    const name = document.getElementById('update-name').value;
+    await fetch('/api/update', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id, name})
+    });
+    fetchData();
+}
+
+async function deleteRow() {
+    const id = document.getElementById('delete-id').value;
+    await fetch('/api/delete', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id})
+    });
+    fetchData();
+}
+
+fetchData();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask server with routes to modify an Excel file
- add HTML frontend for basic CRUD operations
- document setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857cbc03054833383ce161218cc15d1