### PR TITLE
Add option dropdown field stored in Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Excel Manager
 
-This simple Flask application provides a web interface to perform CRUD (create, read, update, delete) operations on a local Excel file.
+This simple Flask application provides a web interface to perform CRUD (create, read, update, delete) operations on a local Excel file. Each record includes an **Option** field with values `test1`, `test2` or `test`.
 
 ## Setup
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ def load_workbook():
     if not os.path.exists(EXCEL_FILE):
         wb = openpyxl.Workbook()
         ws = wb.active
-        ws.append(["ID", "Name"])
+        ws.append(["ID", "Name", "Option"])
         wb.save(EXCEL_FILE)
     return openpyxl.load_workbook(EXCEL_FILE)
 
@@ -22,7 +22,7 @@ def read_data():
     ws = wb.active
     data = []
     for row in ws.iter_rows(min_row=2, values_only=True):
-        data.append({"id": row[0], "name": row[1]})
+        data.append({"id": row[0], "name": row[1], "option": row[2]})
     return data
 
 
@@ -40,11 +40,12 @@ def list_data():
 def add_row():
     id_ = request.json.get('id')
     name = request.json.get('name')
-    if not id_ or not name:
-        return jsonify({"error": "id and name required"}), 400
+    option = request.json.get('option')
+    if not id_ or not name or option is None:
+        return jsonify({"error": "id, name and option required"}), 400
     wb = load_workbook()
     ws = wb.active
-    ws.append([id_, name])
+    ws.append([id_, name, option])
     wb.save(EXCEL_FILE)
     return jsonify({"success": True})
 
@@ -53,13 +54,15 @@ def add_row():
 def update_row():
     id_ = request.json.get('id')
     name = request.json.get('name')
-    if not id_ or not name:
-        return jsonify({"error": "id and name required"}), 400
+    option = request.json.get('option')
+    if not id_ or name is None or option is None:
+        return jsonify({"error": "id, name and option required"}), 400
     wb = load_workbook()
     ws = wb.active
     for row in ws.iter_rows(min_row=2):
         if str(row[0].value) == str(id_):
             row[1].value = name
+            row[2].value = option
             wb.save(EXCEL_FILE)
             return jsonify({"success": True})
     return jsonify({"error": "ID not found"}), 404

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
 
 <table id="data-table">
     <thead>
-    <tr><th>ID</th><th>Name</th></tr>
+    <tr><th>ID</th><th>Name</th><th>Option</th></tr>
     </thead>
     <tbody></tbody>
 </table>
@@ -21,11 +21,21 @@
 <h2>Add Row</h2>
 <input id="add-id" placeholder="ID">
 <input id="add-name" placeholder="Name">
+<select id="add-option">
+    <option value="test1">test1</option>
+    <option value="test2">test2</option>
+    <option value="test">test</option>
+</select>
 <button onclick="addRow()">Add</button>
 
 <h2>Update Row</h2>
 <input id="update-id" placeholder="ID">
 <input id="update-name" placeholder="New Name">
+<select id="update-option">
+    <option value="test1">test1</option>
+    <option value="test2">test2</option>
+    <option value="test">test</option>
+</select>
 <button onclick="updateRow()">Update</button>
 
 <h2>Delete Row</h2>
@@ -40,7 +50,7 @@ async function fetchData() {
     tbody.innerHTML = '';
     for (const row of data) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${row.id}</td><td>${row.name}</td>`;
+        tr.innerHTML = `<td>${row.id}</td><td>${row.name}</td><td>${row.option}</td>`;
         tbody.appendChild(tr);
     }
 }
@@ -48,10 +58,11 @@ async function fetchData() {
 async function addRow() {
     const id = document.getElementById('add-id').value;
     const name = document.getElementById('add-name').value;
+    const option = document.getElementById('add-option').value;
     await fetch('/api/add', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({id, name})
+        body: JSON.stringify({id, name, option})
     });
     fetchData();
 }
@@ -59,10 +70,11 @@ async function addRow() {
 async function updateRow() {
     const id = document.getElementById('update-id').value;
     const name = document.getElementById('update-name').value;
+    const option = document.getElementById('update-option').value;
     await fetch('/api/update', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({id, name})
+        body: JSON.stringify({id, name, option})
     });
     fetchData();
 }


### PR DESCRIPTION
## Summary
- include an `Option` field in the Excel sheet
- allow choosing among `test1`, `test2`, or `test` on the webpage
- save and update the selected option in the workbook
- display the option column on the site

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6857cee80e248333afa4fb496237b482